### PR TITLE
add github actions deploy workflow

### DIFF
--- a/.env.deploy.template
+++ b/.env.deploy.template
@@ -1,0 +1,4 @@
+SSH_HOST=mattjackson.uk
+SSH_PORT=22
+SSH_USER=majackson
+SSH_PASSWORD=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy to mattjackson.uk
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2  # v1.2.5
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          port: ${{ secrets.SSH_PORT }}
+          username: ${{ secrets.SSH_USER }}
+          password: ${{ secrets.SSH_PASSWORD }}
+          script_stop: true
+          script: |
+            set -e
+            cd ~/bowelism
+            git pull --ff-only
+            docker compose up -d --build

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ static/
 
 production.env
 .env
+.env.deploy


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy.yml` — on push to `master` (and `workflow_dispatch`), SSHes to `mattjackson.uk` and runs `git pull --ff-only && docker compose up -d --build` in `~/bowelism`. `appleboy/ssh-action` is pinned to a commit SHA (v1.2.5) rather than a tag to harden against supply-chain compromise on a third-party action that sees the SSH password at runtime.
- Adds `.env.deploy.template` — placeholder shape for the four SSH secrets (`SSH_HOST`, `SSH_PORT`, `SSH_USER`, `SSH_PASSWORD`).
- Adds `.env.deploy` to `.gitignore` so the real, populated copy never lands in version control.

Replaces the current manual flow (ssh in → `docker compose down` → `git pull` → rebuild → `docker compose up`). `docker compose up -d --build` builds new images alongside the running containers and only recreates services whose image changed — less downtime than the down-then-up dance.

## Test plan

- [ ] Set the four secrets in GitHub before merging: `gh secret set SSH_HOST/SSH_PORT/SSH_USER/SSH_PASSWORD`
- [ ] Merge this PR
- [ ] Watch the run on the Actions tab — confirm the SSH step's stdout shows the `git pull` advancing the server's HEAD and `docker compose` recreating only changed services
- [ ] SSH to the server and confirm `git rev-parse HEAD` matches the merge commit and `docker compose ps` shows all 5 services Up
- [ ] Load `https://mattjackson.uk` and confirm the page renders and the log-streaming websocket connects

🤖 Generated with [Claude Code](https://claude.com/claude-code)