### PR TITLE
remove unsupported script_stop input from ssh-action deploy step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,6 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           username: ${{ secrets.SSH_USER }}
           password: ${{ secrets.SSH_PASSWORD }}
-          script_stop: true
           script: |
             set -e
             cd ~/bowelism


### PR DESCRIPTION
appleboy/ssh-action@v1.2.5 doesn't accept script_stop, causing an "unexpected input" warning on every deploy run. Redundant anyway since the script already sets -e.