### PR TITLE
add toggle to pause live-scrolling log output

### DIFF
--- a/bowelism/media/css/styles.css
+++ b/bowelism/media/css/styles.css
@@ -227,6 +227,62 @@ h3 {
   color: var(--blue);
 }
 
+/* Live-scroll toggle */
+.log-toggle-wrapper {
+    position: fixed;
+    top: 0.85rem;
+    right: 1rem;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-family: 'Source Sans 3', sans-serif;
+    font-size: 0.7rem;
+    color: var(--base1);
+    cursor: pointer;
+    user-select: none;
+    background: rgba(253, 246, 227, 0.75);
+    backdrop-filter: blur(4px);
+    padding: 0.3rem 0.5rem;
+    border-radius: 6px;
+}
+
+.log-toggle-input {
+    display: none;
+}
+
+.log-toggle-switch {
+    position: relative;
+    display: inline-block;
+    width: 28px;
+    height: 16px;
+    background-color: var(--base2);
+    border-radius: 8px;
+    transition: background-color 0.2s;
+    flex-shrink: 0;
+}
+
+.log-toggle-switch::after {
+    content: '';
+    position: absolute;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: white;
+    top: 2px;
+    left: 2px;
+    transition: left 0.2s;
+    box-shadow: 0 1px 2px rgba(0, 43, 54, 0.2);
+}
+
+.log-toggle-input:checked + .log-toggle-switch {
+    background-color: var(--base01);
+}
+
+.log-toggle-input:checked + .log-toggle-switch::after {
+    left: 14px;
+}
+
 /* Responsive design */
 @media (max-width: 768px) {
   .content-card {

--- a/bowelism/templates/index.html
+++ b/bowelism/templates/index.html
@@ -27,6 +27,10 @@
         REMOTE_IP: "{{ remote_ip }}",
         log_lines_container: null,
         log_stream_socket: null,
+        live_scrolling_enabled: true,
+        buffered_lines: [],
+        toggle_label: null,
+        toggle_input: null,
 
         init: function() {
             this.log_lines_container = document.getElementsByClassName(this.LOG_LINES_CONTAINER_CLASS)[0];
@@ -39,13 +43,34 @@
             this.log_stream_socket.onerror = e => {
                 console.error("Socket closed unexpectedly");
             };
+
+            this.toggle_label = document.getElementById('log-toggle-label');
+            this.toggle_input = document.getElementById('log-toggle-input');
+            this.toggle_input.addEventListener('change', () => this.toggle_live_scrolling());
+        },
+
+        toggle_live_scrolling: function() {
+            this.live_scrolling_enabled = !this.live_scrolling_enabled;
+            if (this.live_scrolling_enabled) {
+                this.toggle_label.textContent = 'Disable Live-Scrolling HTTP Logs';
+                if (this.buffered_lines.length > 0) {
+                    this.received_log_lines(this.buffered_lines);
+                    this.buffered_lines = [];
+                }
+            } else {
+                this.toggle_label.textContent = 'Enable Live-Scrolling HTTP Logs';
+            }
         },
 
         received_log_lines: function(lines) {
-            for (let [idx, line] of lines.entries()) {
-                setTimeout(() => {
-                    this.received_log_line(line);
-                }, 100*idx);
+            if (!this.live_scrolling_enabled) {
+                this.buffered_lines = this.buffered_lines.concat(lines);
+            } else {
+                for (let [idx, line] of lines.entries()) {
+                    setTimeout(() => {
+                        this.received_log_line(line);
+                    }, 100*idx);
+                }
             }
         },
 
@@ -91,6 +116,12 @@
 {% endblock %}
 
 {% block content %}
+<label class="log-toggle-wrapper" id="log-toggle-wrapper">
+    <span id="log-toggle-label">Disable Live-Scrolling HTTP Logs</span>
+    <input type="checkbox" class="log-toggle-input" id="log-toggle-input">
+    <span class="log-toggle-switch"></span>
+</label>
+
 <div class="terminal-container">
     <div class="terminal-text">
     </div>


### PR DESCRIPTION
Adds a small iOS-style toggle fixed to the top-right corner that lets readers pause the streaming log feed without closing the websocket. New lines are buffered while paused and replayed with the same 100ms stagger mechanic when re-enabled. Toggle label flips between "Disable / Enable Live-Scrolling HTTP Logs" to reflect the action available. Styled in muted Solarized tones with a semi-transparent frosted-glass backdrop for legibility over the scrolling terminal text.