### PR TITLE
run collectstatic during deploy so static asset changes actually ship

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,4 +24,7 @@ jobs:
             set -e
             cd ~/bowelism
             git pull --ff-only
-            docker compose up -d --build
+            docker compose build
+            docker compose run --rm --no-deps web \
+              bash -c "source ~/.venvs/bowelismvenv/bin/activate && python manage.py collectstatic --no-input"
+            docker compose up -d


### PR DESCRIPTION
the deploy only ran `docker compose up -d --build`, which rebuilds images but never runs collectstatic. STATIC_ROOT (./static) is gitignored and populated solely by collectstatic, so changed css/images never reached nginx or S3 on deploy. build explicitly, collect static in a one-shot web container, then bring containers up.